### PR TITLE
Making git log command ignore local, custom log formatting

### DIFF
--- a/lib/gitalytics.rb
+++ b/lib/gitalytics.rb
@@ -26,7 +26,7 @@ class Gitalytics
 
   private
   def parse_git_log
-    result = `git log --stat`
+    result = `git log --stat --format=`
 
     result.each_line do |line|
       if match = line.match(/^commit ([0-9a-z]*)$/)


### PR DESCRIPTION
I use a custom format for git log (something akin to git log --oneline with a few more bits of info). That custom formatting was breaking your gitalytics log parsing. Adding the --format= option to the git log command removes any formatting and ensures that git log is always returning parsable text.
