### PR TITLE
Fix for accented author names being omitted from stats.

### DIFF
--- a/lib/gitalytics.rb
+++ b/lib/gitalytics.rb
@@ -29,7 +29,7 @@ class Gitalytics
     result = `git log --stat`
 
     result.each_line do |line|
-      line.encode!('UTF-8', 'UTF8-MAC')
+      line.encode!('UTF-8', 'UTF8-MAC') if defined?(Encoding::UTF8_MAC)
 
       if match = line.match(/^commit ([0-9a-z]*)$/)
         @data[:commits] << Commit.new(match[1])


### PR DESCRIPTION
Accented author names weren't being found due to the regex searching with \w instead of [:alpha:], which is accent-safe, so I changed that.

However, for that regex to work the encoding of the string (returned from `git log --stat`) needed to be enforced. As per [this SO answer](http://stackoverflow.com/a/13194139):

> Ruby 1.9 and 2.0 will use composed UTF-8 strings if you use UTF-8 encoding, but will not modify strings received from the OS. Mac OS X uses decomposed strings (two bytes for many common accents like é in UTF-8, which are combined for display). So file system methods will often return unexpected string formats, which are strictly UTF-8, but a decomposed form.
> 
> In order to work around this, you need to decompose them by converting from the 'UTF8-MAC' encoding to UTF-8
