### PR TITLE
Open browser

### DIFF
--- a/lib/gitalytics.rb
+++ b/lib/gitalytics.rb
@@ -59,14 +59,14 @@ class Gitalytics
     erb = ERB.new(template_file)
     output_file = "gitalytics_result.html"
     File.open(output_file, 'w+') { |file| file.write(erb.result(binding)) }
-	host = RbConfig::CONFIG['host_os']
-	if host =~ /mswin|mingw|cygwin/
-	  system "start #{output_file}"
-	elsif host =~ /darwin/
-	  system "open #{output_file}"
-	elsif host =~ /linux|bsd/
-	  system "xdg-open #{output_file}"
-	end
+    host = RbConfig::CONFIG['host_os']
+    if host =~ /mswin|mingw|cygwin/
+      system "start #{output_file}"
+    elsif host =~ /darwin/
+      system "open #{output_file}"
+    elsif host =~ /linux|bsd/ 
+      system "xdg-open #{output_file}"
+    end
   end
 
   def get_user(name, email)


### PR DESCRIPTION
It would be nice if the browser opens up automatically and shows the html report generated after entering the command 'gitalytics -h'.
