### PR TITLE
Simplify log parsing

### DIFF
--- a/lib/commit.rb
+++ b/lib/commit.rb
@@ -8,11 +8,11 @@ class Commit
   end
 
   def insertions
-    summary.map{ |s| s[:insertions].length }.inject(0){ |total, current| total + current }
+    summary.inject(0) { |total, current| total + current[:insertions] }
   end
 
   def deletions
-    summary.map{ |s| s[:deletions].length }.inject(0){ |total, current| total + current }
+    summary.inject(0) { |total, current| total + current[:deletions] }
   end
 
   def files_committed

--- a/lib/gitlog.rb
+++ b/lib/gitlog.rb
@@ -20,12 +20,12 @@ module GitLog
   end
 
   def get_log
-    `git log --stat --format=`
+    `git log --numstat --pretty='%H %ai %an <%ae> %s'`
   end
 
   def get_blocks(log_string)
-    commits = log_string.scan(/^commit ([a-f0-9]+)$/).map(&:first)
-    blocks = log_string.split(/^commit [a-f0-9]+$/).map(&:strip)
+    commits = log_string.scan(/^([a-f0-9]{40})/).map(&:first)
+    blocks = log_string.split(/^[a-f0-9]{40}/).map(&:strip)
     blocks.shift # get rid of first empty string
 
     commits.zip(blocks)
@@ -36,40 +36,29 @@ module GitLog
 
     block_string.encode!('UTF-8', 'UTF8-MAC') if defined?(Encoding::UTF8_MAC)
 
-    get_commit_author(block_string, commit, users)
-    get_commit_date(block_string, commit)
-    get_commit_message(block_string, commit)
+    regex = /^(?<date>.{25}) (?<name>.*?) \<(?<email>.*?)> (?<subject>.*?)$/
+    data = block_string.match(regex)
+    commit.subject = data[:subject]
+    commit.date = Date.parse(data[:date])
+
+    get_commit_author(data, commit, users)
     get_commit_summary(block_string, commit)
 
     commit
   end
 
   def get_commit_summary(block_string, commit)
-    block_string.scan(/^ ([^ ]+)[ ]+\|[ ]+([\d]+) ([\+]*)([-]*)$/).each do |summary|
+    block_string.scan(/^(?<insertions>\d+)\s+(?<deletions>\d+)\s+(?<filename>.*)$/).each do |summary|
       commit.summary << {
-        filename: summary[0],
-        changes: summary[1],
-        insertions: summary[2],
-        deletions: summary[3]
+        insertions: summary[0].to_i,
+        deletions: summary[1].to_i,
+        filename: summary[2],
       }
     end
   end
 
-  def get_commit_date(block_string, commit)
-    date = block_string.match(/^Date:   (.*)$/)[0]
-    commit.date = Date.parse(date)
-  end
-
-  def get_commit_message(block_string, commit)
-    message = block_string.match(/^\n(?:\s{4}.*\n?)+$/)[0]
-    message.gsub!(/^[ ]{4}/, '').strip!
-    commit.subject = message.lines.first
-    commit.subject.strip!
-  end
-
-  def get_commit_author(block_string, commit, users)
-    author = block_string.match(/^Author: ([[:alpha:] ]*) <(.*)>$/)
-    user = get_user(author[1], author[2], users)
+  def get_commit_author(data, commit, users)
+    user = get_user(data[:name], data[:email], users)
 
     commit.author = user
     user.commits << commit

--- a/test/lib/test_commit.rb
+++ b/test/lib/test_commit.rb
@@ -9,15 +9,13 @@ class TestCommit < MiniTest::Unit::TestCase
 
   def build_commit(commit)
     commit.summary << {
-      changes: 5,
-      insertions: '+++',
-      deletions: '--',
+      insertions: 3,
+      deletions: 2,
       filename: 'a.rb'
     }
     commit.summary << {
-      changes: 7,
-      insertions: '++++',
-      deletions: '---',
+      insertions: 4,
+      deletions: 3,
       filename: 'b.rb'
     }
   end

--- a/test/lib/test_gitlog.rb
+++ b/test/lib/test_gitlog.rb
@@ -4,71 +4,44 @@ require 'gitlog'
 class TestCommit < MiniTest::Unit::TestCase
 
   def git_log
-    %q(commit bea63e76c7c6d5afd42ac5b24a911b36e5c261f9
-Author: Gonzalo Robaina <gonzalor@gmail.com>
-Date:   Wed Feb 13 23:11:16 2013 -0200
 
-    Print basic commit report on the console
+    %q(bea63e76c7c6d5afd42ac5b24a911b36e5c261f9 2013-02-13 23:11:16 -0200 Gonzalo Robaina <gonzalor@gmail.com> Print basic commit report on the console
 
- bin/gitalytics    |  7 ++++++-
- lib/gitalytics.rb | 39 +++++++++++++++++++++++++++++++++------
- 2 files changed, 39 insertions(+), 7 deletions(-)
+6       1       bin/gitalytics
+33      6       lib/gitalytics.rb
+d392710a9e657c72e73ca87df3ed2c8c802441e4 2012-12-19 06:04:59 -0800 Gonzalo Robaina <gonzalor@gmail.com> Initial commit
 
-commit d392710a9e657c72e73ca87df3ed2c8c802441e4
-Author: Gonzalo Robaina <gonzalor@gmail.com>
-Date:   Wed Dec 19 06:04:59 2012 -0800
+16      0       .gitignore
+4       0       README.md
+9a99ae5dbc1eaadf268ca925cce9b68d10216151 2012-12-06 10:29:49 -0200 Gonzalo Robaina <gonzalor@gmail.com> initial commit
 
-    Initial commit
-
- .gitignore | 16 ++++++++++++++++
- README.md  |  4 ++++
- 2 files changed, 20 insertions(+)
-
-commit 9a99ae5dbc1eaadf268ca925cce9b68d10216151
-Author: Gonzalo Robaina <gonzalor@gmail.com>
-Date:   Thu Dec 6 10:29:49 2012 -0200
-
-    initial commit
-
- README.md          |  1 +
- bin/gitalytics     |  3 +++
- gitalytics.gemspec | 13 +++++++++++++
- lib/gist.rb        | 49 +++++++++++++++++++++++++++++++++++++++++++++++++
- lib/gitalytics.rb  | 11 +++++++++++
- 5 files changed, 77 insertions(+))
+1       0       README.md
+3       0       bin/gitalytics
+13      0       gitalytics.gemspec
+49      0       lib/gist.rb
+11      0       lib/gitalytics.rb
+)
   end
 
   def test_get_blocks
     expected_blocks = [
-      %q(Author: Gonzalo Robaina <gonzalor@gmail.com>
-Date:   Wed Feb 13 23:11:16 2013 -0200
+      %q(2013-02-13 23:11:16 -0200 Gonzalo Robaina <gonzalor@gmail.com> Print basic commit report on the console
 
-    Print basic commit report on the console
+6       1       bin/gitalytics
+33      6       lib/gitalytics.rb),
 
- bin/gitalytics    |  7 ++++++-
- lib/gitalytics.rb | 39 +++++++++++++++++++++++++++++++++------
- 2 files changed, 39 insertions(+), 7 deletions(-)),
+      %q(2012-12-19 06:04:59 -0800 Gonzalo Robaina <gonzalor@gmail.com> Initial commit
 
-      %q(Author: Gonzalo Robaina <gonzalor@gmail.com>
-Date:   Wed Dec 19 06:04:59 2012 -0800
+16      0       .gitignore
+4       0       README.md),
 
-    Initial commit
+      %q(2012-12-06 10:29:49 -0200 Gonzalo Robaina <gonzalor@gmail.com> initial commit
 
- .gitignore | 16 ++++++++++++++++
- README.md  |  4 ++++
- 2 files changed, 20 insertions(+)),
-
-      %q(Author: Gonzalo Robaina <gonzalor@gmail.com>
-Date:   Thu Dec 6 10:29:49 2012 -0200
-
-    initial commit
-
- README.md          |  1 +
- bin/gitalytics     |  3 +++
- gitalytics.gemspec | 13 +++++++++++++
- lib/gist.rb        | 49 +++++++++++++++++++++++++++++++++++++++++++++++++
- lib/gitalytics.rb  | 11 +++++++++++
- 5 files changed, 77 insertions(+))
+1       0       README.md
+3       0       bin/gitalytics
+13      0       gitalytics.gemspec
+49      0       lib/gist.rb
+11      0       lib/gitalytics.rb)
     ]
 
     expected_commits = [
@@ -121,22 +94,13 @@ Date:   Thu Dec 6 10:29:49 2012 -0200
   end
 
   def test_get_commit_author_links_user_and_commit
-    blocks = GitLog.get_blocks(git_log)
-    hash, block = blocks.last
+    data = { name: 'test', email: 'test@email.com' }
     commit = Commit.new(hash)
     users = []
 
-    GitLog.get_commit_author(block, commit, users)
+    GitLog.get_commit_author(data, commit, users)
     assert_equal(users.last, commit.author)
     assert_equal(users.last.commits.last, commit)
-  end
-
-  def test_get_commit_message_with_no_new_line_at_end
-    block_string = "Author: User <email@example.com>\nDate:   Mon Jan 20 00:00:00 2014 -0100\n\n    Some commit\n    \n    A little description"
-    commit = Commit.new('abcdef')
-
-    GitLog.get_commit_message(block_string, commit)
-    assert_equal('Some commit', commit.subject)
   end
 
 end

--- a/test/lib/test_user.rb
+++ b/test/lib/test_user.rb
@@ -19,27 +19,23 @@ class TestUser < MiniTest::Unit::TestCase
   def create_commits(user)
     user.commits << create_commit('abcdef', '2000-01-10', [{ # weekday: 1
       filename: 'a.rb',
-      changes: 1,
-      insertions: '+',
-      deletions: '',
+      insertions: 1,
+      deletions: 0,
     }])
     user.commits << create_commit('abcdef', '2000-01-01', [{ # weekday: 6
       filename: 'c.rb',
-      changes: 0,
-      insertions: '',
-      deletions: '-',
+      insertions: 0,
+      deletions: 1,
     }])
     user.commits << create_commit('abcdef', '2000-01-01', [{ # weekday: 6
       filename: 'd.rb',
-      changes: 9,
-      insertions: '++++',
-      deletions: '-----'
+      insertions: 4,
+      deletions: 5
     }])
     user.commits << create_commit('abcdef', '2000-01-08', [{ # weekday: 6
       filename: 'e.rb',
-      changes: 2,
-      insertions: '+',
-      deletions: '-'
+      insertions: 1,
+      deletions: 1
     }])
   end
 


### PR DESCRIPTION
Use a custom format on `git log` that allows an easier data manipulation.
Plus, `Commit` no longer store insertions as `+++` and deletions as `---`, but as numbers.
